### PR TITLE
feat: enabled custom RecognizerOptions via dc.prompt

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     return Task.FromResult(result);
                 }
 
-                var opt = RecognizerOptions ?? new FindChoicesOptions();
+                var opt = ObjectPath.Assign<FindChoicesOptions>(RecognizerOptions ?? new FindChoicesOptions(), options.RecognizerOptions);
                 opt.Locale = DetermineCulture(activity, opt);
                 var results = ChoiceRecognizers.RecognizeChoices(utterance, choices, opt);
                 if (results != null && results.Count > 0)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -51,5 +51,12 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <value>Additional options for use with a prompt validator.</value>
         public object Validations { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional options passed to the underlying
+        /// <see cref="ChoiceRecognizers.RecognizeChoices(string, IList{Choice}, FindChoicesOptions)"/> method.
+        /// </summary>
+        /// <value>Options to control the recognition strategy.</value>
+        public FindChoicesOptions RecognizerOptions { get; set; }
     }
 }


### PR DESCRIPTION
Fixes (botbuilder-js) [#3945](https://github.com/microsoft/botbuilder-js/issues/3945)
Reference:  [PR-3964] (https://github.com/microsoft/botbuilder-js/pull/3964)

## Description
Allow to merge recognizerOptions (such as recognizeNumbers, recognizeOrdinals, etc.) from the prompt object with the options in context.prompt call, as the latter were only used to get the choices, but didn't allow to set options for the recognizer.

## Specific Changes
- Allow to merge recognizerOptions in the prompt object with recognizerOptions in the context.prompt call.
- Added recognizerOptions property to PromptOptions interface, as it is required by previous point.

## Testing
I added two choice prompt tests, one with default recognizerOptions (with recognizeNumbers: true) and other overriding this recognizerOptions in context.prompt call, the first understand numbers, and the second doesn't, as expected.